### PR TITLE
chore: add npm bugs and homepage metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,5 +63,9 @@
     "env": {
       "node": true
     }
+  },
+  "homepage": "https://github.com/keplersj/jest-raw-loader#readme",
+  "bugs": {
+    "url": "https://github.com/keplersj/jest-raw-loader/issues"
   }
 }


### PR DESCRIPTION
Adds missing `bugs.url` and `homepage` to `package.json` so npm users can navigate to the issue tracker and README from the package page.